### PR TITLE
Django extensions 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: MIT
 
 Feedstock license: BSD 3-Clause
 
-Summary: Extensions for Django.
+Summary: Extensions for Django
 
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,8 @@ requirements:
     - python
     - six >=1.2
     # Pinning Django to versions not failing the testsuite
-    - django ==1.8 #[py3k]
-    - django <=1.8 #[py2k]
+    - django ==1.8  #[py3k]
+    - django <=1.8  #[py2k]
   
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ requirements:
   run:
     - python
     - six >=1.2
-		# Pinning Django to versions not failing the testsuite
+    # Pinning Django to versions not failing the testsuite
     - django ==1.8 #[py3k]
     - django <=1.8 #[py2k]
   

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,8 @@ requirements:
     - python
     - six >=1.2
     # Pinning Django to versions not failing the testsuite
-    - django ==1.8  #[py3k]
-    - django <=1.8  #[py2k]
+    - django ==1.8  # [py3k]
+    - django <=1.8  # [py2k]
   
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.2" %}
+{% set version = "1.5.0" %}
 
 package:
   name: django-extensions
@@ -6,11 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/django-extensions/django-extensions-{{ version }}.tar.gz
-  sha256: 1f626353a11479014bfe0d77e76d8f866ebca1bb5d595cb57b776230b9e0eb92
+  sha256: 2e44532500f3720e5b7b4e3ac483fa6e0c5e3feadc132791f08b6ed4ee9ca704
 
 build:
   number: 0
-  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -20,9 +19,10 @@ requirements:
   run:
     - python
     - six >=1.2
-    - django >=1.7
-    - typing
-
+		# Pinning Django to versions not failing the testsuite
+    - django ==1.8.* #[py35 or py36]
+    - django <=1.8.* #[py27 or py34]
+  
 test:
   imports:
     - django_extensions

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
@@ -20,8 +21,7 @@ requirements:
     - python
     - six >=1.2
     # Pinning Django to versions not failing the testsuite
-    - django ==1.8  # [py3k]
-    - django <=1.8  # [py2k]
+    - django <=1.8
   
 test:
   imports:
@@ -31,7 +31,7 @@ about:
   home: http://github.com/django-extensions/django-extensions
   license: MIT
   license_file: LICENSE
-  summary: 'Extensions for Django.'
+  summary: 'Extensions for Django'
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.1.2" %}
+{% set version = "1.5.0" %}
 
 package:
   name: django-extensions
@@ -6,11 +6,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/django-extensions/django-extensions-{{ version }}.tar.gz
-  sha256: 1f626353a11479014bfe0d77e76d8f866ebca1bb5d595cb57b776230b9e0eb92
+  sha256: 2e44532500f3720e5b7b4e3ac483fa6e0c5e3feadc132791f08b6ed4ee9ca704
 
 build:
   number: 0
-  noarch: python
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -20,9 +19,10 @@ requirements:
   run:
     - python
     - six >=1.2
-    - django >=1.7
-    - typing
-
+		# Pinning Django to versions not failing the testsuite
+    - django ==1.8 #[py3k]
+    - django <=1.8 #[py2k]
+  
 test:
   imports:
     - django_extensions


### PR DESCRIPTION
Hi @ocefpaf @kwilcox,

here's my recipe for django-extensions==1.5.0. Unfortunately I had to pin the django versions down to ==1.8 and <=1.8 for python3 and python2 respectively to make the tests work (ran them locally). I hope you're fine with that.

Best,
Andreas